### PR TITLE
Fix admin status route failing after login

### DIFF
--- a/app/api/admin/status/route.ts
+++ b/app/api/admin/status/route.ts
@@ -7,15 +7,14 @@ export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 export async function GET() {
-  const res = NextResponse.next()
-  res.headers.set('Cache-Control', 'no-store, private, max-age=0')
+  const headers = new Headers({ 'Cache-Control': 'no-store, private, max-age=0' })
 
   const token = cookies().get('sid')?.value
   if (!token) {
     if (process.env.NODE_ENV !== 'production') {
       console.debug('[admin/status/debug] No token found')
     }
-    return NextResponse.json({ role: 'none' }, { headers: res.headers })
+    return NextResponse.json({ role: 'none' }, { headers })
   }
 
   try {
@@ -24,25 +23,25 @@ export async function GET() {
       if (process.env.NODE_ENV !== 'production') {
         console.debug('[admin/status/debug] AUTH_SECRET not set')
       }
-      return NextResponse.json({ role: 'none' }, { headers: res.headers })
+      return NextResponse.json({ role: 'none' }, { headers })
     }
-    
+
     const { payload } = await jwtVerify(token, secret) // throws on bad/expired
     const role = payload.role === 'super_admin' ? 'super_admin'
               : payload.role === 'admin' ? 'admin'
               : 'none'
-    
+
     if (process.env.NODE_ENV !== 'production') {
       console.debug('[admin/status/debug] JWT verified successfully:', { role, exp: payload.exp })
     }
-    
-    return NextResponse.json({ role }, { headers: res.headers })
+
+    return NextResponse.json({ role }, { headers })
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
       console.debug('[admin/status/debug] JWT verification failed:', error)
     }
     // clear bad/expired cookie
     cookies().set('sid', '', { httpOnly: true, path: '/', maxAge: 0 })
-    return NextResponse.json({ role: 'none' }, { headers: res.headers })
+    return NextResponse.json({ role: 'none' }, { headers })
   }
 }


### PR DESCRIPTION
## Summary
- avoid use of `NextResponse.next()` in admin status route causing 500 errors
- return status with caching headers using standard `NextResponse.json`

## Testing
- `npm run lint`
- `curl -b /tmp/cookies.txt -i http://localhost:3000/api/admin/status/`


------
https://chatgpt.com/codex/tasks/task_e_68c7dbe29c38832882729757545d0063