### PR TITLE
Fix admin status and item routes failing after login

### DIFF
--- a/app/api/admin/status/route.ts
+++ b/app/api/admin/status/route.ts
@@ -7,15 +7,14 @@ export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 export async function GET() {
-  const res = NextResponse.next()
-  res.headers.set('Cache-Control', 'no-store, private, max-age=0')
+  const headers = new Headers({ 'Cache-Control': 'no-store, private, max-age=0' })
 
   const token = cookies().get('sid')?.value
   if (!token) {
     if (process.env.NODE_ENV !== 'production') {
       console.debug('[admin/status/debug] No token found')
     }
-    return NextResponse.json({ role: 'none' }, { headers: res.headers })
+    return NextResponse.json({ role: 'none' }, { headers })
   }
 
   try {
@@ -24,25 +23,25 @@ export async function GET() {
       if (process.env.NODE_ENV !== 'production') {
         console.debug('[admin/status/debug] AUTH_SECRET not set')
       }
-      return NextResponse.json({ role: 'none' }, { headers: res.headers })
+      return NextResponse.json({ role: 'none' }, { headers })
     }
-    
+
     const { payload } = await jwtVerify(token, secret) // throws on bad/expired
     const role = payload.role === 'super_admin' ? 'super_admin'
               : payload.role === 'admin' ? 'admin'
               : 'none'
-    
+
     if (process.env.NODE_ENV !== 'production') {
       console.debug('[admin/status/debug] JWT verified successfully:', { role, exp: payload.exp })
     }
-    
-    return NextResponse.json({ role }, { headers: res.headers })
+
+    return NextResponse.json({ role }, { headers })
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
       console.debug('[admin/status/debug] JWT verification failed:', error)
     }
     // clear bad/expired cookie
     cookies().set('sid', '', { httpOnly: true, path: '/', maxAge: 0 })
-    return NextResponse.json({ role: 'none' }, { headers: res.headers })
+    return NextResponse.json({ role: 'none' }, { headers })
   }
 }

--- a/app/api/arena/title/route.ts
+++ b/app/api/arena/title/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/jwt-auth'
 import { readState, writeState } from '@/lib/state'
 

--- a/app/api/items/addText/route.ts
+++ b/app/api/items/addText/route.ts
@@ -1,6 +1,32 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { readState, writeState, ensureItemStats, expectedScore, kFactor, ensurePair, sanitizeItem, uploadsDir } from '@/lib/state'
-import { cookies } from 'next/headers'
-import fs from 'fs'
-import path from 'path'
-export async function POST(req:NextRequest){const s=readState(); const rc=cookies().get('role')?.value; if(!(rc==='admin'||rc==='super_admin')) return new NextResponse('forbidden',{status:403}); const body=await req.json(); const name=String(body?.name||'').trim(); if(!name) return new NextResponse('bad name',{status:400}); const id='txt-'+crypto.randomUUID(); s.items.push({id, name}); if(!s.globalRatings[id]) s.globalRatings[id]=1500; s.wins[id]=0; s.appearances[id]=0; writeState(s); return NextResponse.json({ok:true}) }
+import { getCurrentUser } from '@/lib/jwt-auth'
+import { readState, writeState } from '@/lib/state'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export async function POST(req: NextRequest) {
+  const { role, error } = await getCurrentUser()
+  if (error) return error
+  if (role === 'none') return new NextResponse('unauthorized', { status: 401 })
+
+  const s = readState()
+
+  let name = ''
+  try {
+    name = String((await req.json())?.name || '').trim()
+  } catch {
+    return new NextResponse('bad_payload', { status: 400 })
+  }
+  if (!name) return new NextResponse('bad_input', { status: 400 })
+  if (name.length > 120) name = name.slice(0, 120)
+
+  const id = 'txt-' + crypto.randomUUID()
+  s.items.push({ id, name })
+  if (!s.globalRatings[id]) s.globalRatings[id] = 1500
+  s.wins[id] = 0
+  s.appearances[id] = 0
+  writeState(s)
+  return Response.json({ ok: true, id, name })
+}

--- a/app/api/items/remove/route.ts
+++ b/app/api/items/remove/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/jwt-auth'
 import { writeState, readState } from '@/lib/state'
 

--- a/app/api/items/upload/route.ts
+++ b/app/api/items/upload/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/jwt-auth'
 import { readState, writeState, uploadsDir } from '@/lib/state'
 import fs from 'fs'

--- a/app/api/signin/enable/route.ts
+++ b/app/api/signin/enable/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getCurrentUser } from '@/lib/jwt-auth'
 import { readState, writeState } from '@/lib/state'
 


### PR DESCRIPTION
## Summary
- avoid use of `NextResponse.next()` in admin status route causing 500 errors
- return status with caching headers using standard `NextResponse.json`
- add missing `NextResponse` imports in API routes to fix TypeScript build
- authorize item creation and rename routes via JWT `getCurrentUser`, letting new text items appear in admin panel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7dbe29c38832882729757545d0063