### PR TITLE
Fix arena vote button availability

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -133,7 +133,7 @@ export default function Home() {
   const busyRef = useRef(false)
 
   const canVote = (!signInEnabled || signedIn) && !!pair && !busy
-  useEffect(() => { canVoteRef.current = (!signInEnabled || signedIn) && !!pairRef.current && !busyRef.current }, [signInEnabled, signedIn, pair, busy])
+  useEffect(() => { canVoteRef.current = canVote }, [canVote])
   useEffect(() => { pairRef.current = pair }, [pair])
   useEffect(() => { busyRef.current = busy }, [busy])
 


### PR DESCRIPTION
## Summary
- ensure the client-side vote handler tracks the derived canVote value instead of a stale ref
- fixes arena buttons not invoking votes in production, allowing matchups and leaderboards to refresh

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c872b068b08328bc51d47d98778de3