### PR TITLE
Fix vote availability ref updates

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -133,7 +133,9 @@ export default function Home() {
   const busyRef = useRef(false)
 
   const canVote = (!signInEnabled || signedIn) && !!pair && !busy
-  useEffect(() => { canVoteRef.current = (!signInEnabled || signedIn) && !!pairRef.current && !busyRef.current }, [signInEnabled, signedIn, pair, busy])
+  useEffect(() => {
+    canVoteRef.current = (!signInEnabled || signedIn) && !!pair && !busy
+  }, [signInEnabled, signedIn, pair, busy])
   useEffect(() => { pairRef.current = pair }, [pair])
   useEffect(() => { busyRef.current = busy }, [busy])
 


### PR DESCRIPTION
## Summary
- keep the vote-availability ref in sync with the latest state values so the buttons stay clickable after a vote in production

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c872b068b08328bc51d47d98778de3