### PR TITLE
Adjust arena spacing for better layout

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -440,7 +440,7 @@ export default function AdminPage() {
                   <textarea
                     value={allowedNamesText}
                     onChange={(e) => setAllowedNamesText(e.target.value)}
-                    placeholder="alice\nbob"
+                    placeholder={'Alice\nBob'}
                     className="w-full h-40 rounded-3xl border border-border bg-bg backdrop-blur-md p-4 text-sm leading-relaxed shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_6px_20px_rgba(0,0,0,0.15)]"
                   />
                   <div className="flex items-center gap-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -240,8 +240,8 @@ export default function Home() {
   function renderItem(it: Item | null) {
     if (!it) return null
     return (
-      <div className="flex flex-col items-center gap-3">
-        {it.imageUrl ? <img src={it.imageUrl} alt={it.name} className="rounded-xl max-h-[360px]" /> : null}
+      <div className="flex flex-col items-center gap-4">
+        {it.imageUrl ? <img src={it.imageUrl} alt={it.name} className="rounded-xl max-h-[320px]" /> : null}
         <div className="text-sm text-text">{it.name}</div>
       </div>
     )
@@ -311,9 +311,9 @@ export default function Home() {
         </Card>
       ) : (
         <Card>
-          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] items-start gap-6 p-6">
-            <div className="flex flex-col items-center gap-4">
-              <div className="flex items-center justify-center md:h-[360px] w-full">
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] items-start gap-6 px-6 py-8">
+            <div className="flex flex-col items-center gap-6">
+              <div className="flex items-center justify-center md:h-[400px] w-full">
                 {renderItem(pair ? pair[0] : null)}
               </div>
               <button
@@ -325,9 +325,9 @@ export default function Home() {
                 {(!signInEnabled || signedIn) ? 'Choose Left (←)' : 'Sign in to vote'}
               </button>
             </div>
-            <div className="flex items-center justify-center text-subtext text-sm md:px-4 md:h-[360px] text-center">vs</div>
-            <div className="flex flex-col items-center gap-4">
-              <div className="flex items-center justify-center md:h-[360px] w-full">
+            <div className="flex items-center justify-center text-subtext text-sm md:px-4 md:h-[400px] text-center">vs</div>
+            <div className="flex flex-col items-center gap-6">
+              <div className="flex items-center justify-center md:h-[400px] w-full">
                 {renderItem(pair ? pair[1] : null)}
               </div>
               <button


### PR DESCRIPTION
## Summary
- increase the arena card padding and column gaps to give more room around the matchup content
- reduce the maximum item image height and raise the matchup column height to provide more vertical breathing space around images
- widen the spacing between item labels and vote buttons so labels are not crowded above the controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c872b068b08328bc51d47d98778de3