### PR TITLE
Fix state persistence after uploads

### DIFF
--- a/lib/state.ts
+++ b/lib/state.ts
@@ -85,10 +85,17 @@ const BLOB_CACHE_MS = 2000
 let readPromise: Promise<State> | null = null
 let lastBlobCheck = 0
 
+function cloneStateValue(state: State): State {
+  if (typeof (globalThis as any).structuredClone === 'function') {
+    return (globalThis as any).structuredClone(state) as State
+  }
+  return JSON.parse(JSON.stringify(state)) as State
+}
+
 export async function readState(): Promise<State> {
   if (useBlob) {
     if (cachedState && Date.now() - lastBlobCheck < BLOB_CACHE_MS) {
-      return cachedState
+      return cloneStateValue(cachedState)
     }
     if (readPromise) return readPromise
     readPromise = (async () => {
@@ -97,7 +104,7 @@ export async function readState(): Promise<State> {
         const uploadedAt = meta.uploadedAt.toISOString()
         if (cachedState && cachedUploadedAt === uploadedAt) {
           lastBlobCheck = Date.now()
-          return cachedState
+          return cloneStateValue(cachedState)
         }
 
         const res = await fetch(meta.downloadUrl || meta.url, { cache: 'no-store' })
@@ -106,27 +113,27 @@ export async function readState(): Promise<State> {
         cachedState = JSON.parse(text) as State
         cachedUploadedAt = uploadedAt
         lastBlobCheck = Date.now()
-        return cachedState
+        return cloneStateValue(cachedState)
       } catch (err) {
         if (err instanceof BlobNotFoundError || (err as any)?.name === 'BlobNotFoundError') {
           const fresh = defaultState()
           cachedState = fresh
           cachedUploadedAt = null
           lastBlobCheck = Date.now()
-          return fresh
+          return cloneStateValue(fresh)
         }
         if (process.env.NODE_ENV !== 'production') {
           console.error('Failed to read arena state from blob, using cached/default state', err)
         }
         if (cachedState) {
           lastBlobCheck = Date.now()
-          return cachedState
+          return cloneStateValue(cachedState)
         }
         const fallback = defaultState()
         cachedState = fallback
         cachedUploadedAt = null
         lastBlobCheck = Date.now()
-        return fallback
+        return cloneStateValue(fallback)
       } finally {
         readPromise = null
       }
@@ -134,7 +141,7 @@ export async function readState(): Promise<State> {
     return readPromise
   }
 
-  if (cachedState) return cachedState
+  if (cachedState) return cloneStateValue(cachedState)
   if (readPromise) return readPromise
 
   readPromise = (async () => {
@@ -142,7 +149,7 @@ export async function readState(): Promise<State> {
       await ensureDirs()
       const text = await fsp.readFile(dataPath, 'utf-8')
       cachedState = JSON.parse(text) as State
-      return cachedState
+      return cloneStateValue(cachedState)
     } catch (err: any) {
       if (err && err.code === 'ENOENT') {
         const s = defaultState()
@@ -152,13 +159,13 @@ export async function readState(): Promise<State> {
         } catch (writeErr) {
           warnOnce('Failed to write arena state file, state will be kept in memory only.', writeErr)
         }
-        return s
+        return cloneStateValue(s)
       }
       warnOnce('Failed to read arena state file, using in-memory cache instead.', err)
-      if (cachedState) return cachedState
+      if (cachedState) return cloneStateValue(cachedState)
       const fallback = defaultState()
       cachedState = fallback
-      return fallback
+      return cloneStateValue(fallback)
     } finally {
       readPromise = null
     }
@@ -167,25 +174,29 @@ export async function readState(): Promise<State> {
 }
 
 export async function writeState(s: State): Promise<void> {
-  cachedState = s
   if (useBlob) {
     lastBlobCheck = Date.now()
-    await put('state.json', JSON.stringify(s), {
+    const serialized = JSON.stringify(s)
+    const { uploadedAt } = await put('state.json', serialized, {
       access: 'public',
       contentType: 'application/json',
       addRandomSuffix: false,
       allowOverwrite: true,
       token: blobToken,
     })
-    cachedUploadedAt = new Date().toISOString()
+    cachedState = JSON.parse(serialized) as State
+    cachedUploadedAt = uploadedAt?.toISOString() || new Date().toISOString()
     return
   }
   await ensureDirs()
+  const serialized = JSON.stringify(s, null, 2)
   try {
-    await fsp.writeFile(dataPath, JSON.stringify(s, null, 2))
+    await fsp.writeFile(dataPath, serialized)
   } catch (err) {
     warnOnce('Failed to persist arena state to disk, continuing with in-memory state.', err)
+    throw err
   }
+  cachedState = JSON.parse(serialized) as State
 }
 
 export function kFactor() {


### PR DESCRIPTION
## Summary
- return cloned copies of the arena state from `readState` so callers never mutate the cached state directly
- only replace the cached state after persisting and propagate write failures, preventing silent drops when disk or blob storage is unavailable
- reuse serialized JSON for caching metadata, keeping blob timestamps in sync with remote storage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c94535536083288d202149323d6c1a