### PR TITLE
Add persistent fallback for uploaded images

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -6,7 +6,7 @@ import { Section } from '@/components/Section'
 import { useDialog } from '@/components/DialogProvider'
 import FancySelect from '@/components/FancySelect'
 
-type Item = { id: string; name: string; imageUrl?: string | null }
+type Item = { id: string; name: string; imageUrl?: string | null; imageData?: string | null }
 type Role = 'none' | 'admin' | 'super_admin'
 
 export default function AdminPage() {
@@ -271,8 +271,12 @@ export default function AdminPage() {
       <div className="space-y-2">
         {items.map((it) => (
           <div key={it.id} className="flex items-center gap-4 border border-border rounded-2xl p-4 shadow-[0_8px_30px_rgba(0,0,0,0.20)] hover:shadow-[0_14px_40px_rgba(0,0,0,0.35)] transition-shadow">
-            {it.imageUrl ? (
-              <img src={it.imageUrl} alt={it.name} className="h-16 w-16 object-cover rounded-2xl" />
+            {it.imageData || it.imageUrl ? (
+              <img
+                src={it.imageData || it.imageUrl || undefined}
+                alt={it.name}
+                className="h-16 w-16 object-cover rounded-2xl"
+              />
             ) : (
               <div className="h-16 w-16 flex items-center justify-center rounded-2xl border border-border text-xs text-subtext">
                 Text

--- a/app/api/items/upload/route.ts
+++ b/app/api/items/upload/route.ts
@@ -32,6 +32,11 @@ export async function POST(req: NextRequest) {
 
       const buffer = Buffer.from(await f.arrayBuffer())
 
+      const mimeType = f.type?.trim() || (ext === 'jpg' ? 'image/jpeg' : `image/${ext}`)
+      const imageData = !useBlob
+        ? `data:${mimeType};base64,${buffer.toString('base64')}`
+        : null
+
       let url: string
       if (useBlob) {
         const { url: blobUrl } = await put(`uploads/${id}.${ext}`, buffer, {
@@ -50,7 +55,7 @@ export async function POST(req: NextRequest) {
       if (!base) base = originalName
       if (base.length > 120) base = base.slice(0, 120)
 
-      return { id, name: base, imageUrl: url }
+      return { id, name: base, imageUrl: url, imageData }
     }),
   )
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import Card from '@/components/Card'
 import { Section } from '@/components/Section'
 
-type Item = { id: string; name: string; imageUrl?: string | null }
+type Item = { id: string; name: string; imageUrl?: string | null; imageData?: string | null }
 type Pair = [Item, Item]
 type PersonalMode = 'anon' | 'signedIn' | 'signedOut'
 type GlobalRow = { rank: number; id: string; name: string; rating: number; w: number; l: number; wp: number }
@@ -67,6 +67,7 @@ function normalizeHomePayload(data: any): HomePayload {
           id: String(it?.id || ''),
           name: String(it?.name || ''),
           imageUrl: typeof it?.imageUrl === 'string' ? it.imageUrl : null,
+          imageData: typeof it?.imageData === 'string' ? it.imageData : null,
         }))
         .filter((it: Item) => it.id && it.name)
     : []
@@ -79,11 +80,13 @@ function normalizeHomePayload(data: any): HomePayload {
       id: String(first?.id || ''),
       name: String(first?.name || ''),
       imageUrl: typeof first?.imageUrl === 'string' ? first.imageUrl : null,
+      imageData: typeof first?.imageData === 'string' ? first.imageData : null,
     }
     const b: Item = {
       id: String(second?.id || ''),
       name: String(second?.name || ''),
       imageUrl: typeof second?.imageUrl === 'string' ? second.imageUrl : null,
+      imageData: typeof second?.imageData === 'string' ? second.imageData : null,
     }
     if (a.id && a.name && b.id && b.name) {
       pair = [a, b]
@@ -364,9 +367,10 @@ export default function Home() {
 
   function renderItem(it: Item | null) {
     if (!it) return null
+    const src = it.imageData || it.imageUrl || null
     return (
       <div className="flex flex-col items-center gap-4">
-        {it.imageUrl ? <img src={it.imageUrl} alt={it.name} className="rounded-xl max-h-[320px]" /> : null}
+        {src ? <img src={src} alt={it.name} className="rounded-xl max-h-[320px]" /> : null}
         <div className="text-sm text-text">{it.name}</div>
       </div>
     )

--- a/lib/arena.ts
+++ b/lib/arena.ts
@@ -1,6 +1,11 @@
 import { sanitizeItem, type Item, type State } from '@/lib/state'
 
-export type PublicItem = { id: string; name: string; imageUrl?: string | null }
+export type PublicItem = {
+  id: string
+  name: string
+  imageUrl?: string | null
+  imageData?: string | null
+}
 export type Pair = [PublicItem, PublicItem]
 export type GlobalLeaderboardRow = {
   rank: number

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -2,7 +2,12 @@ import path from 'path'
 import { promises as fsp } from 'fs'
 import { BlobNotFoundError, head, put } from '@vercel/blob'
 
-export type Item = { id: string; name: string; imageUrl?: string | null }
+export type Item = {
+  id: string
+  name: string
+  imageUrl?: string | null
+  imageData?: string | null
+}
 
 export type State = {
   arenaTitle: string
@@ -204,7 +209,12 @@ export function ensureItemStats(s: State, id: string) {
 
 export function sanitizeItem(s: State, it: Item) {
   const name = s.nameOverrides[it.id] || it.name
-  return { id: it.id, name, imageUrl: it.imageUrl || null }
+  return {
+    id: it.id,
+    name,
+    imageUrl: it.imageUrl || null,
+    imageData: it.imageData || null,
+  }
 }
 
 export async function ensurePair(


### PR DESCRIPTION
## Summary
- extend the stored item shape to include a base64 `imageData` fallback so uploaded images survive reloads even if the file system is ephemeral
- capture the data URL when processing uploads (while still using blob storage when configured)
- render admin and public images via the new fallback field when a regular URL is unavailable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c94535536083288d202149323d6c1a