### PR TITLE
Fix blob upload URL to persist images across reloads

### DIFF
--- a/app/api/items/upload/route.ts
+++ b/app/api/items/upload/route.ts
@@ -44,7 +44,17 @@ export async function POST(req: NextRequest) {
           contentType: f.type || 'application/octet-stream',
           token: process.env.BLOB_READ_WRITE_TOKEN,
         })
-        url = blobUrl
+        let cleanUrl = blobUrl
+        try {
+          const parsed = new URL(blobUrl)
+          parsed.search = ''
+          parsed.hash = ''
+          cleanUrl = parsed.toString()
+        } catch {
+          const idx = blobUrl.indexOf('?')
+          cleanUrl = idx >= 0 ? blobUrl.slice(0, idx) : blobUrl
+        }
+        url = cleanUrl
       } else {
         const filePath = path.join(uploadsDir, `${id}.${ext}`)
         await fsp.writeFile(filePath, buffer)


### PR DESCRIPTION
## Summary
- ensure uploaded blob URLs are normalised to a stable form without transient query parameters
- keep the rest of the upload logic intact so images stay visible after a page reload

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c94f148b3c832895e2ab45ab356007